### PR TITLE
Fix GitHub Actions security scanning issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-test
     
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -102,7 +107,7 @@ jobs:
           output: 'trivy-results.sarif'
           
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
- Update CodeQL action from deprecated v2 to v3
- Add required permissions for security-events write access
- Fix 'Resource not accessible by integration' error
- Maintain security scanning functionality in CI pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)